### PR TITLE
Enhance tracing and metrics reporting in Solace utilities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ testngVersion=7.6.1
 eclipseLsp4jVersion=0.12.0
 ballerinaGradlePluginVersion=2.3.0
 ballerinaLangVersion=2201.12.0
+openTelemetryVersion=1.32.0
 solaceJcsmpVersion=10.28.3
 nettyVersion=4.1.135.Final
 commonsLoggingVersion=1.3.5

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstylePluginVersion}"
 
     implementation group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
+    // OpenTelemetry context/propagation API - shaded into the Ballerina runtime at run time (declared 'runtime'
+    // scope by ballerina-runtime), so it is compileOnly here. Needed to read the active provider's propagator
+    // fields via TracersStore, keeping trace-context propagation provider-agnostic (not hardcoded to W3C).
+    compileOnly group: 'io.opentelemetry', name: 'opentelemetry-context', version: "${openTelemetryVersion}"
     implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     implementation group: 'org.ballerinalang', name: 'value', version: "${ballerinaLangVersion}"
     implementation group: 'com.solacesystems', name: 'sol-jcsmp', version: "${solaceJcsmpVersion}"

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -29,9 +29,6 @@ dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstylePluginVersion}"
 
     implementation group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
-    // OpenTelemetry context/propagation API - shaded into the Ballerina runtime at run time (declared 'runtime'
-    // scope by ballerina-runtime), so it is compileOnly here. Needed to read the active provider's propagator
-    // fields via TracersStore, keeping trace-context propagation provider-agnostic (not hardcoded to W3C).
     compileOnly group: 'io.opentelemetry', name: 'opentelemetry-context', version: "${openTelemetryVersion}"
     implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     implementation group: 'org.ballerinalang', name: 'value', version: "${ballerinaLangVersion}"

--- a/native/src/main/java/io/xlibb/solace/common/CommonUtils.java
+++ b/native/src/main/java/io/xlibb/solace/common/CommonUtils.java
@@ -26,7 +26,6 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.xlibb.solace.ModuleUtils;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -92,24 +91,23 @@ public class CommonUtils {
     }
 
     /**
-     * Computes the best-effort byte size of a Ballerina Solace message's payload, for observability metrics.
+     * Computes the byte size of a Ballerina Solace message's payload, for observability metrics.
+     * <p>
+     * The message {@code payload} is typed {@code byte[]}, so its size is exactly the array length. Any other
+     * shape (which the record type does not permit) is reported as 0 rather than estimated.
      *
      * @param message the Ballerina message record
      * @return the payload size in bytes, or 0 if it cannot be determined
      */
-    @SuppressWarnings("unchecked")
     public static int getPayloadSize(BMap<BString, Object> message) {
         if (message == null) {
             return 0;
         }
         Object payload = message.get(PAYLOAD_KEY);
         if (payload instanceof BArray arr) {
+            // byte[] payload: the wire size is exactly the array length.
             return arr.size();
         }
-        if (payload instanceof BString str) {
-            return str.getValue().getBytes(StandardCharsets.UTF_8).length;
-        }
-        // Best-effort only: exact byte-accounting for other payload shapes (record/map/etc.) is not attempted.
         return 0;
     }
 

--- a/native/src/main/java/io/xlibb/solace/common/CommonUtils.java
+++ b/native/src/main/java/io/xlibb/solace/common/CommonUtils.java
@@ -20,12 +20,18 @@ package io.xlibb.solace.common;
 
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 import io.xlibb.solace.ModuleUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+
+import static io.xlibb.solace.common.MessageFieldConstants.PAYLOAD_KEY;
 
 /**
  * Utility class for common operations like error creation and virtual thread execution.
@@ -83,6 +89,28 @@ public class CommonUtils {
             }
         });
         return future.get();
+    }
+
+    /**
+     * Computes the best-effort byte size of a Ballerina Solace message's payload, for observability metrics.
+     *
+     * @param message the Ballerina message record
+     * @return the payload size in bytes, or 0 if it cannot be determined
+     */
+    @SuppressWarnings("unchecked")
+    public static int getPayloadSize(BMap<BString, Object> message) {
+        if (message == null) {
+            return 0;
+        }
+        Object payload = message.get(PAYLOAD_KEY);
+        if (payload instanceof BArray arr) {
+            return arr.size();
+        }
+        if (payload instanceof BString str) {
+            return str.getValue().getBytes(StandardCharsets.UTF_8).length;
+        }
+        // Best-effort only: exact byte-accounting for other payload shapes (record/map/etc.) is not attempted.
+        return 0;
     }
 
     /**

--- a/native/src/main/java/io/xlibb/solace/consumer/ConsumerActions.java
+++ b/native/src/main/java/io/xlibb/solace/consumer/ConsumerActions.java
@@ -27,7 +27,6 @@ import com.solacesystems.jcsmp.XMLMessage;
 import com.solacesystems.jcsmp.XMLMessageConsumer;
 import com.solacesystems.jcsmp.transaction.TransactedSession;
 import io.ballerina.runtime.api.Environment;
-import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
@@ -53,7 +52,6 @@ import static io.xlibb.solace.common.Constants.NATIVE_SUBSCRIPTION_TYPE;
 import static io.xlibb.solace.common.Constants.NATIVE_TRANSACTED;
 import static io.xlibb.solace.common.Constants.NATIVE_TX_SESSION;
 import static io.xlibb.solace.common.Constants.NATIVE_URL;
-import static io.xlibb.solace.common.MessageFieldConstants.PAYLOAD_KEY;
 import static io.xlibb.solace.consumer.ConsumerUtils.SUBSCRIPTION_TYPE_DIRECT_TOPIC;
 import static io.xlibb.solace.consumer.ConsumerUtils.SUBSCRIPTION_TYPE_DURABLE_TOPIC;
 import static io.xlibb.solace.consumer.ConsumerUtils.SUBSCRIPTION_TYPE_QUEUE;
@@ -67,7 +65,6 @@ import static io.xlibb.solace.observability.SolaceObservabilityConstants.ERROR_T
 import static io.xlibb.solace.observability.SolaceObservabilityConstants.ERROR_TYPE_NACK;
 import static io.xlibb.solace.observability.SolaceObservabilityConstants.ERROR_TYPE_RECEIVE;
 import static io.xlibb.solace.observability.SolaceObservabilityConstants.ERROR_TYPE_ROLLBACK;
-import static io.xlibb.solace.observability.SolaceObservabilityConstants.UNKNOWN;
 
 /**
  * Consumer actions - main entry point for Ballerina MessageConsumer interop.
@@ -116,7 +113,7 @@ public class ConsumerActions {
             consumer.addNativeData(NATIVE_URL, url.getValue());
 
             // Store destination name for observability
-            String destinationName = extractDestinationName(subscriptionConfig);
+            String destinationName = ConsumerUtils.extractDestinationName(subscriptionConfig);
             consumer.addNativeData(NATIVE_DESTINATION, destinationName);
 
             // Create appropriate consumer based on subscription type
@@ -145,17 +142,6 @@ public class ConsumerActions {
             SolaceMetricsUtil.reportConnectionError(CONTEXT_CONSUMER);
             return CommonUtils.createError("Failed to initialize consumer", e);
         }
-    }
-
-    private static String extractDestinationName(ConsumerSubscriptionConfig subscriptionConfig) {
-        if (subscriptionConfig instanceof QueueConsumerConfig queueConfig) {
-            String name = queueConfig.queueName();
-            return name != null ? name : UNKNOWN;
-        } else if (subscriptionConfig instanceof TopicConsumerConfig topicConfig) {
-            String name = topicConfig.topicName();
-            return name != null ? name : UNKNOWN;
-        }
-        return UNKNOWN;
     }
 
     /**
@@ -207,8 +193,9 @@ public class ConsumerActions {
                 return bError;
             }
             if (result != null) {
-                int size = getPayloadSize((BMap<BString, Object>) result);
-                SolaceMetricsUtil.reportConsume(consumer, size);
+                BMap<BString, Object> receivedMessage = (BMap<BString, Object>) result;
+                SolaceMetricsUtil.reportConsume(consumer, CommonUtils.getPayloadSize(receivedMessage));
+                SolaceTracingUtil.tagUpstreamTraceContext(env, receivedMessage);
             }
             return result;
         } catch (Exception e) {
@@ -263,8 +250,9 @@ public class ConsumerActions {
                 return bError;
             }
             if (result != null) {
-                int size = getPayloadSize((BMap<BString, Object>) result);
-                SolaceMetricsUtil.reportConsume(consumer, size);
+                BMap<BString, Object> receivedMessage = (BMap<BString, Object>) result;
+                SolaceMetricsUtil.reportConsume(consumer, CommonUtils.getPayloadSize(receivedMessage));
+                SolaceTracingUtil.tagUpstreamTraceContext(env, receivedMessage);
             }
             return result;
         } catch (Exception e) {
@@ -472,17 +460,5 @@ public class ConsumerActions {
             SolaceMetricsUtil.reportConsumerError(consumer, ERROR_TYPE_CLOSE);
             return CommonUtils.createError("Failed to close consumer", e);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static int getPayloadSize(BMap<BString, Object> message) {
-        if (message == null) {
-            return 0;
-        }
-        Object payload = message.get(PAYLOAD_KEY);
-        if (payload instanceof BArray arr) {
-            return arr.size();
-        }
-        return 0;
     }
 }

--- a/native/src/main/java/io/xlibb/solace/consumer/ConsumerUtils.java
+++ b/native/src/main/java/io/xlibb/solace/consumer/ConsumerUtils.java
@@ -38,6 +38,7 @@ import static io.xlibb.solace.common.Constants.NATIVE_CONSUMER;
 import static io.xlibb.solace.common.Constants.NATIVE_FLOW;
 import static io.xlibb.solace.common.Constants.NATIVE_SESSION;
 import static io.xlibb.solace.common.Constants.NATIVE_SUBSCRIPTION_TYPE;
+import static io.xlibb.solace.observability.SolaceObservabilityConstants.UNKNOWN;
 
 /**
  * Utility class for consumer-related operations.
@@ -47,6 +48,23 @@ public class ConsumerUtils {
     public static final String SUBSCRIPTION_TYPE_QUEUE = "QUEUE";
     public static final String SUBSCRIPTION_TYPE_DIRECT_TOPIC = "DIRECT_TOPIC";
     public static final String SUBSCRIPTION_TYPE_DURABLE_TOPIC = "DURABLE_TOPIC";
+
+    /**
+     * Extracts the destination name (queue or topic) from a subscription config, for observability tags.
+     *
+     * @param subscriptionConfig the consumer subscription configuration
+     * @return the queue or topic name, or {@code UNKNOWN} if it cannot be determined
+     */
+    public static String extractDestinationName(ConsumerSubscriptionConfig subscriptionConfig) {
+        if (subscriptionConfig instanceof QueueConsumerConfig queueConfig) {
+            String name = queueConfig.queueName();
+            return name != null ? name : UNKNOWN;
+        } else if (subscriptionConfig instanceof TopicConsumerConfig topicConfig) {
+            String name = topicConfig.topicName();
+            return name != null ? name : UNKNOWN;
+        }
+        return UNKNOWN;
+    }
 
     /**
      * Configures common flow properties from a consumer subscription config. Applies to both queue and durable topic

--- a/native/src/main/java/io/xlibb/solace/listener/ListenerActions.java
+++ b/native/src/main/java/io/xlibb/solace/listener/ListenerActions.java
@@ -172,8 +172,11 @@ public class ListenerActions {
             caller.addNativeData(NATIVE_TX_SESSION, txSession);
             caller.addNativeData(NATIVE_CLOSED, false);
 
+            String url = (String) listener.getNativeData(NATIVE_URL);
+            String destinationName = ConsumerUtils.extractDestinationName(subscriptionConfig);
             SolaceMessageListener messageListener =
-                    new SolaceMessageListener(runtime, service, caller, hasCaller, hasOnError, autoAck);
+                    new SolaceMessageListener(runtime, service, caller, hasCaller, hasOnError, autoAck, url,
+                            destinationName);
 
             AttachedService attached = createReceiver(session, txSession, isTransacted, subscriptionConfig,
                     messageListener);

--- a/native/src/main/java/io/xlibb/solace/listener/SolaceMessageListener.java
+++ b/native/src/main/java/io/xlibb/solace/listener/SolaceMessageListener.java
@@ -99,11 +99,7 @@ final class SolaceMessageListener implements XMLMessageListener {
                     t instanceof Exception e ? e : new Exception(t))));
             return;
         }
-        // Reported on arrival, mirroring the pull-based consumer's receive(): counts messages delivered from the
-        // broker, independent of whether the service's onMessage call later succeeds or fails.
         SolaceMetricsUtil.reportConsume(url, destination, CommonUtils.getPayloadSize(ballerinaMessage));
-        // Extracted here (arrival time) rather than inside tracingProperties(), since the latter is also used for
-        // conversion-failure / flow-error dispatches where no message (and so no trace-context) is available.
         Map<String, String> traceContext = SolaceTracingUtil.extractTraceContextHeaders(ballerinaMessage);
         submit(() -> deliver(message, ballerinaMessage, traceContext));
     }
@@ -159,17 +155,6 @@ final class SolaceMessageListener implements XMLMessageListener {
         }
     }
 
-    /**
-     * Seeds a fresh {@link SolaceObserverContext} into the strand properties so the runtime attaches it as the
-     * root span for the invoked {@code onMessage}/{@code onError} method - {@code runtime.callMethod} runs on a
-     * plain dispatch thread with no {@code Environment}, so the usual observer-context-of-current-frame attach
-     * point (used by the pull-based consumer actions) is unavailable here.
-     * <p>
-     * When the message carried a W3C traceparent (published by a Solace producer that had tracing enabled), it is
-     * seeded onto the context via {@code ObservabilityConstants.PROPERTY_TRACE_PROPERTIES} - the runtime's
-     * {@code TracingUtils.startObservation} reads this same property to extract a remote parent span, so the
-     * resulting span is linked as a child of the publisher's span instead of starting a new, disconnected trace.
-     */
     private Map<String, Object> tracingProperties(Map<String, String> traceContext) {
         if (!ObserveUtils.isTracingEnabled()) {
             return null;

--- a/native/src/main/java/io/xlibb/solace/listener/SolaceMessageListener.java
+++ b/native/src/main/java/io/xlibb/solace/listener/SolaceMessageListener.java
@@ -27,13 +27,23 @@ import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.observability.ObservabilityConstants;
+import io.ballerina.runtime.observability.ObserveUtils;
 import io.xlibb.solace.common.CommonUtils;
 import io.xlibb.solace.consumer.MessageConverter;
+import io.xlibb.solace.observability.SolaceMetricsUtil;
+import io.xlibb.solace.observability.SolaceObserverContext;
+import io.xlibb.solace.observability.SolaceTracingUtil;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import static io.xlibb.solace.observability.SolaceObservabilityConstants.CONTEXT_CONSUMER;
+import static io.xlibb.solace.observability.SolaceObservabilityConstants.ERROR_TYPE_RECEIVE;
 
 /**
  * JCSMP asynchronous message listener that bridges broker delivery to a Ballerina service.
@@ -56,16 +66,20 @@ final class SolaceMessageListener implements XMLMessageListener {
     private final boolean hasCaller;
     private final boolean hasOnError;
     private final boolean autoAck;
+    private final String url;
+    private final String destination;
     private final ExecutorService dispatcher;
 
     SolaceMessageListener(Runtime runtime, BObject service, BObject caller, boolean hasCaller, boolean hasOnError,
-                          boolean autoAck) {
+                          boolean autoAck, String url, String destination) {
         this.runtime = runtime;
         this.service = service;
         this.caller = caller;
         this.hasCaller = hasCaller;
         this.hasOnError = hasOnError;
         this.autoAck = autoAck;
+        this.url = url;
+        this.destination = destination;
         this.dispatcher = Executors.newSingleThreadExecutor(runnable -> {
             Thread thread = new Thread(runnable, "solace-listener-dispatch");
             thread.setDaemon(true);
@@ -85,15 +99,22 @@ final class SolaceMessageListener implements XMLMessageListener {
                     t instanceof Exception e ? e : new Exception(t))));
             return;
         }
-        submit(() -> deliver(message, ballerinaMessage));
+        // Reported on arrival, mirroring the pull-based consumer's receive(): counts messages delivered from the
+        // broker, independent of whether the service's onMessage call later succeeds or fails.
+        SolaceMetricsUtil.reportConsume(url, destination, CommonUtils.getPayloadSize(ballerinaMessage));
+        // Extracted here (arrival time) rather than inside tracingProperties(), since the latter is also used for
+        // conversion-failure / flow-error dispatches where no message (and so no trace-context) is available.
+        Map<String, String> traceContext = SolaceTracingUtil.extractTraceContextHeaders(ballerinaMessage);
+        submit(() -> deliver(message, ballerinaMessage, traceContext));
     }
 
-    private void deliver(BytesXMLMessage message, BMap<BString, Object> ballerinaMessage) {
+    private void deliver(BytesXMLMessage message, BMap<BString, Object> ballerinaMessage,
+                         Map<String, String> traceContext) {
         try {
-            Object result = invokeOnMessage(ballerinaMessage);
+            Object result = invokeOnMessage(ballerinaMessage, traceContext);
             if (result instanceof BError bError) {
                 // Processing failed: leave the message unsettled so guaranteed flows redeliver it.
-                dispatchError(bError);
+                dispatchError(bError, traceContext);
                 return;
             }
             // In AUTO_ACK mode the flow is created with client acknowledgement, so settle on success here.
@@ -101,10 +122,10 @@ final class SolaceMessageListener implements XMLMessageListener {
                 message.ackMessage();
             }
         } catch (BError bError) {
-            dispatchError(bError);
+            dispatchError(bError, traceContext);
         } catch (Throwable t) {
             dispatchError(CommonUtils.createError("Failed to dispatch message to service",
-                    t instanceof Exception e ? e : new Exception(t)));
+                    t instanceof Exception e ? e : new Exception(t)), traceContext);
         }
     }
 
@@ -113,8 +134,8 @@ final class SolaceMessageListener implements XMLMessageListener {
         submit(() -> dispatchError(CommonUtils.createError("Solace consumer flow error", exception)));
     }
 
-    private Object invokeOnMessage(BMap<BString, Object> ballerinaMessage) {
-        StrandMetadata metadata = new StrandMetadata(false, null);
+    private Object invokeOnMessage(BMap<BString, Object> ballerinaMessage, Map<String, String> traceContext) {
+        StrandMetadata metadata = new StrandMetadata(false, tracingProperties(traceContext));
         if (hasCaller) {
             return runtime.callMethod(service, ON_MESSAGE, metadata, ballerinaMessage, caller);
         }
@@ -122,14 +143,44 @@ final class SolaceMessageListener implements XMLMessageListener {
     }
 
     private void dispatchError(BError error) {
+        dispatchError(error, null);
+    }
+
+    private void dispatchError(BError error, Map<String, String> traceContext) {
+        SolaceMetricsUtil.reportConsumerError(url, destination, ERROR_TYPE_RECEIVE);
         if (!hasOnError) {
             return;
         }
         try {
-            runtime.callMethod(service, ON_ERROR, new StrandMetadata(false, null), error);
+            StrandMetadata metadata = new StrandMetadata(false, tracingProperties(traceContext));
+            runtime.callMethod(service, ON_ERROR, metadata, error);
         } catch (Throwable ignored) {
             // Suppress secondary failures from the error handler to avoid losing the original error.
         }
+    }
+
+    /**
+     * Seeds a fresh {@link SolaceObserverContext} into the strand properties so the runtime attaches it as the
+     * root span for the invoked {@code onMessage}/{@code onError} method - {@code runtime.callMethod} runs on a
+     * plain dispatch thread with no {@code Environment}, so the usual observer-context-of-current-frame attach
+     * point (used by the pull-based consumer actions) is unavailable here.
+     * <p>
+     * When the message carried a W3C traceparent (published by a Solace producer that had tracing enabled), it is
+     * seeded onto the context via {@code ObservabilityConstants.PROPERTY_TRACE_PROPERTIES} - the runtime's
+     * {@code TracingUtils.startObservation} reads this same property to extract a remote parent span, so the
+     * resulting span is linked as a child of the publisher's span instead of starting a new, disconnected trace.
+     */
+    private Map<String, Object> tracingProperties(Map<String, String> traceContext) {
+        if (!ObserveUtils.isTracingEnabled()) {
+            return null;
+        }
+        SolaceObserverContext ctx = new SolaceObserverContext(CONTEXT_CONSUMER, url, destination);
+        if (traceContext != null && !traceContext.isEmpty()) {
+            ctx.addProperty(ObservabilityConstants.PROPERTY_TRACE_PROPERTIES, traceContext);
+        }
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, ctx);
+        return properties;
     }
 
     private void submit(Runnable task) {

--- a/native/src/main/java/io/xlibb/solace/observability/SolaceMetricsUtil.java
+++ b/native/src/main/java/io/xlibb/solace/observability/SolaceMetricsUtil.java
@@ -92,8 +92,18 @@ public class SolaceMetricsUtil {
         if (!ObserveUtils.isMetricsEnabled()) {
             return;
         }
-        SolaceObserverContext ctx = new SolaceObserverContext(CONTEXT_CONSUMER, getUrl(consumer),
-                getDestination(consumer));
+        reportConsume(getUrl(consumer), getDestination(consumer), size);
+    }
+
+    /**
+     * Reports a consumed message for the push-based listener path, which has no consumer {@link BObject} to read
+     * url/destination native data from - the caller (a {@code service}'s backing receiver) supplies them directly.
+     */
+    public static void reportConsume(String url, String destination, int size) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        SolaceObserverContext ctx = new SolaceObserverContext(CONTEXT_CONSUMER, url, destination);
         incrementCounter(ctx, METRIC_CONSUMED[0], METRIC_CONSUMED[1], 1);
         incrementCounter(ctx, METRIC_CONSUMED_SIZE[0], METRIC_CONSUMED_SIZE[1], size);
     }
@@ -121,6 +131,18 @@ public class SolaceMetricsUtil {
             return;
         }
         SolaceObserverContext ctx = new SolaceObserverContext(CONTEXT_CONSUMER, getUrl(consumer));
+        ctx.addTag(TAG_KEY_ERROR_TYPE, errorType);
+        incrementCounter(ctx, METRIC_ERRORS[0], METRIC_ERRORS[1], 1);
+    }
+
+    /**
+     * Reports a consumer error for the push-based listener path (see {@link #reportConsume(String, String, int)}).
+     */
+    public static void reportConsumerError(String url, String destination, String errorType) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        SolaceObserverContext ctx = new SolaceObserverContext(CONTEXT_CONSUMER, url, destination);
         ctx.addTag(TAG_KEY_ERROR_TYPE, errorType);
         incrementCounter(ctx, METRIC_ERRORS[0], METRIC_ERRORS[1], 1);
     }

--- a/native/src/main/java/io/xlibb/solace/observability/SolaceTracingUtil.java
+++ b/native/src/main/java/io/xlibb/solace/observability/SolaceTracingUtil.java
@@ -19,10 +19,17 @@
 package io.xlibb.solace.observability;
 
 import io.ballerina.runtime.api.Environment;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.xlibb.solace.common.MessageFieldConstants.PROPERTIES_KEY;
 import static io.xlibb.solace.observability.SolaceMetricsUtil.getDestination;
 import static io.xlibb.solace.observability.SolaceMetricsUtil.getUrl;
 import static io.xlibb.solace.observability.SolaceObservabilityConstants.TAG_KEY_DESTINATION;
@@ -32,6 +39,12 @@ import static io.xlibb.solace.observability.SolaceObservabilityConstants.TAG_KEY
  * Tracing utility for the Solace connector.
  */
 public class SolaceTracingUtil {
+
+    // W3C Trace Context header names (https://www.w3.org/TR/trace-context/), carried verbatim as message
+    // properties so a publisher's span and a consumer's span can be correlated across the broker hop.
+    private static final String TRACEPARENT_KEY = "traceparent";
+    private static final String TRACESTATE_KEY = "tracestate";
+    private static final String TAG_KEY_UPSTREAM_PREFIX = "upstream.";
 
     public static void traceResourceInvocation(Environment env, BObject object, String destination) {
         if (!ObserveUtils.isTracingEnabled()) {
@@ -57,6 +70,79 @@ public class SolaceTracingUtil {
         }
         ctx.addTag(TAG_KEY_URL, getUrl(object));
         ctx.addTag(TAG_KEY_DESTINATION, getDestination(object));
+    }
+
+    /**
+     * Returns the current span's context as a W3C traceparent/tracestate carrier, suitable for injecting into an
+     * outbound message's properties so a downstream consumer can correlate its trace with this publish.
+     *
+     * @param env the Ballerina environment of the publishing native call
+     * @return the carrier map, or null if tracing is disabled or there is no active span to propagate
+     */
+    public static Map<String, String> getTraceContextHeaders(Environment env) {
+        if (!ObserveUtils.isTracingEnabled()) {
+            return null;
+        }
+        ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+        if (ctx == null) {
+            return null;
+        }
+        return ObserveUtils.getContextProperties(ctx);
+    }
+
+    /**
+     * Reads the W3C traceparent/tracestate entries (if any) out of a received Ballerina message's {@code properties}
+     * field.
+     *
+     * @param message the Ballerina message record
+     * @return a (possibly empty) carrier map of the trace-context entries found
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, String> extractTraceContextHeaders(BMap<BString, Object> message) {
+        Map<String, String> carrier = new HashMap<>();
+        if (message == null) {
+            return carrier;
+        }
+        Object propsObj = message.get(PROPERTIES_KEY);
+        if (!(propsObj instanceof BMap)) {
+            return carrier;
+        }
+        BMap<BString, Object> props = (BMap<BString, Object>) propsObj;
+        putIfPresent(carrier, props, TRACEPARENT_KEY);
+        putIfPresent(carrier, props, TRACESTATE_KEY);
+        return carrier;
+    }
+
+    /**
+     * Tags the ambient span (of a pull-based {@code receive}/{@code receiveNoWait} client action) with the
+     * upstream trace-context carried on the received message. The span for these client actions is already started
+     * by the time the native call runs - before the message (and so its trace-context) is known - so a genuine
+     * parent-span link isn't possible here; the extracted context is surfaced as tags instead, for manual
+     * correlation across the publish/consume boundary.
+     *
+     * @param env     the Ballerina environment of the receiving native call
+     * @param message the received Ballerina message record
+     */
+    public static void tagUpstreamTraceContext(Environment env, BMap<BString, Object> message) {
+        if (!ObserveUtils.isTracingEnabled()) {
+            return;
+        }
+        Map<String, String> carrier = extractTraceContextHeaders(message);
+        if (carrier.isEmpty()) {
+            return;
+        }
+        ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+        if (ctx == null) {
+            return;
+        }
+        carrier.forEach((key, value) -> ctx.addTag(TAG_KEY_UPSTREAM_PREFIX + key, value));
+    }
+
+    private static void putIfPresent(Map<String, String> carrier, BMap<BString, Object> props, String key) {
+        Object value = props.get(StringUtils.fromString(key));
+        if (value != null) {
+            carrier.put(key, value.toString());
+        }
     }
 
     private SolaceTracingUtil() {

--- a/native/src/main/java/io/xlibb/solace/observability/SolaceTracingUtil.java
+++ b/native/src/main/java/io/xlibb/solace/observability/SolaceTracingUtil.java
@@ -25,7 +25,10 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
+import io.ballerina.runtime.observability.tracer.TracersStore;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,10 +43,7 @@ import static io.xlibb.solace.observability.SolaceObservabilityConstants.TAG_KEY
  */
 public class SolaceTracingUtil {
 
-    // W3C Trace Context header names (https://www.w3.org/TR/trace-context/), carried verbatim as message
-    // properties so a publisher's span and a consumer's span can be correlated across the broker hop.
-    private static final String TRACEPARENT_KEY = "traceparent";
-    private static final String TRACESTATE_KEY = "tracestate";
+    // Prefix applied when surfacing an upstream message's trace-context as tags on a pull-based receive span.
     private static final String TAG_KEY_UPSTREAM_PREFIX = "upstream.";
 
     public static void traceResourceInvocation(Environment env, BObject object, String destination) {
@@ -73,8 +73,11 @@ public class SolaceTracingUtil {
     }
 
     /**
-     * Returns the current span's context as a W3C traceparent/tracestate carrier, suitable for injecting into an
-     * outbound message's properties so a downstream consumer can correlate its trace with this publish.
+     * Returns the current span's context serialized by the configured OpenTelemetry propagator (W3C
+     * traceparent/tracestate, Jaeger uber-trace-id, B3, etc. - whichever the active tracing provider installs),
+     * suitable for injecting into an outbound message's properties so a downstream consumer can correlate its
+     * trace with this publish. {@code ObserveUtils.getContextProperties} delegates to
+     * {@code TracersStore.getPropagators()}, so this is provider-agnostic by construction.
      *
      * @param env the Ballerina environment of the publishing native call
      * @return the carrier map, or null if tracing is disabled or there is no active span to propagate
@@ -91,8 +94,12 @@ public class SolaceTracingUtil {
     }
 
     /**
-     * Reads the W3C traceparent/tracestate entries (if any) out of a received Ballerina message's {@code properties}
-     * field.
+     * Reads the trace-context entries (if any) out of a received Ballerina message's {@code properties} field.
+     * <p>
+     * The exact property keys are not assumed to be W3C {@code traceparent}/{@code tracestate}: they are taken from
+     * the configured OpenTelemetry propagator's {@link io.opentelemetry.context.propagation.TextMapPropagator#fields()}
+     * - the same fields the publishing side injected via {@link #getTraceContextHeaders} - so extraction stays
+     * correct whatever propagation format the active tracing provider uses.
      *
      * @param message the Ballerina message record
      * @return a (possibly empty) carrier map of the trace-context entries found
@@ -108,9 +115,22 @@ public class SolaceTracingUtil {
             return carrier;
         }
         BMap<BString, Object> props = (BMap<BString, Object>) propsObj;
-        putIfPresent(carrier, props, TRACEPARENT_KEY);
-        putIfPresent(carrier, props, TRACESTATE_KEY);
+        for (String field : propagationFields()) {
+            putIfPresent(carrier, props, field);
+        }
         return carrier;
+    }
+
+    /**
+     * The message-property keys the active OpenTelemetry propagator uses to carry trace context, read from
+     * {@link TracersStore}. Returns an empty set when tracing is not initialized so callers degrade to a no-op.
+     */
+    private static Collection<String> propagationFields() {
+        TracersStore store = TracersStore.getInstance();
+        if (!store.isInitialized()) {
+            return Collections.emptyList();
+        }
+        return store.getPropagators().getTextMapPropagator().fields();
     }
 
     /**

--- a/native/src/main/java/io/xlibb/solace/producer/ProducerActions.java
+++ b/native/src/main/java/io/xlibb/solace/producer/ProducerActions.java
@@ -22,6 +22,7 @@ import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
 import com.solacesystems.jcsmp.ProducerFlowProperties;
+import com.solacesystems.jcsmp.SDTMap;
 import com.solacesystems.jcsmp.XMLMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 import com.solacesystems.jcsmp.transaction.TransactedSession;
@@ -38,6 +39,8 @@ import io.xlibb.solace.config.ConfigurationUtils;
 import io.xlibb.solace.config.ProducerConfiguration;
 import io.xlibb.solace.observability.SolaceMetricsUtil;
 import io.xlibb.solace.observability.SolaceTracingUtil;
+
+import java.util.Map;
 
 import static io.xlibb.solace.common.Constants.NATIVE_CLOSED;
 import static io.xlibb.solace.common.Constants.NATIVE_PRODUCER;
@@ -144,6 +147,7 @@ public class ProducerActions {
             }
 
             XMLMessage jcsmpMessage = MessageConverter.toJCSMPMessage(xmlProducer, message);
+            injectTraceContext(env, jcsmpMessage);
 
             if (destinationMap == null || destinationMap.isEmpty()) {
                 return CommonUtils.createError("Destination must be specified");
@@ -171,6 +175,25 @@ public class ProducerActions {
             SolaceMetricsUtil.reportProducerError(producer, destinationName, ERROR_TYPE_PUBLISH);
             return CommonUtils.createError("Failed to send message", e);
         }
+    }
+
+    /**
+     * Injects the current span's W3C traceparent/tracestate into the outbound message's properties, so a consumer
+     * on the other side of the broker can correlate (or, for a service listener, link) its trace with this publish.
+     */
+    private static void injectTraceContext(Environment env, XMLMessage jcsmpMessage) throws Exception {
+        Map<String, String> traceHeaders = SolaceTracingUtil.getTraceContextHeaders(env);
+        if (traceHeaders == null || traceHeaders.isEmpty()) {
+            return;
+        }
+        SDTMap properties = jcsmpMessage.getProperties();
+        if (properties == null) {
+            properties = JCSMPFactory.onlyInstance().createMap();
+        }
+        for (Map.Entry<String, String> entry : traceHeaders.entrySet()) {
+            properties.putString(entry.getKey(), entry.getValue());
+        }
+        jcsmpMessage.setProperties(properties);
     }
 
     /**

--- a/native/src/main/java/io/xlibb/solace/producer/ProducerActions.java
+++ b/native/src/main/java/io/xlibb/solace/producer/ProducerActions.java
@@ -178,8 +178,7 @@ public class ProducerActions {
     }
 
     /**
-     * Injects the current span's W3C traceparent/tracestate into the outbound message's properties, so a consumer
-     * on the other side of the broker can correlate (or, for a service listener, link) its trace with this publish.
+     * Injects the current span's trace context into the outbound message's properties.
      */
     private static void injectTraceContext(Environment env, XMLMessage jcsmpMessage) throws Exception {
         Map<String, String> traceHeaders = SolaceTracingUtil.getTraceContextHeaders(env);


### PR DESCRIPTION
## Purpose
Add distributed-tracing and metrics observability support to the `xlibb/solace` connector, so that messages flowing through the connector participate in end-to-end traces.

Fixes:
- On the producing side, the connector injects trace context (a `traceparent`) into outbound messages and on the consuming side, the listener extracts that context and seeds it as the remote parent of its` onMessage` span before the span is created, linking each hop into a single connected trace across services. 
- Pull-based `receive()` consumers, which cannot control span creation, instead tag the ambient span with `upstream.traceparent`/`upstream.tracestate` for manual correlation.
- The connector also reports metrics for consumed messages, consumer errors, and payload size, and adds destination-name observability tags.